### PR TITLE
chore: Plasmo関連パッケージを更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "fix": "biome check --write ."
   },
   "dependencies": {
-    "@plasmohq/messaging": "^0.5.0",
-    "@plasmohq/storage": "^1.12.0",
+    "@plasmohq/messaging": "^0.7.2",
+    "@plasmohq/storage": "^1.15.0",
     "@radix-ui/react-popover": "^1.1.1",
     "axios": "^1.7.7",
     "npm-run-all": "^4.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,11 +16,11 @@ importers:
   .:
     dependencies:
       '@plasmohq/messaging':
-        specifier: ^0.5.0
-        version: 0.5.0(react@19.2.0)
+        specifier: ^0.7.2
+        version: 0.7.2(react@19.2.0)
       '@plasmohq/storage':
-        specifier: ^1.12.0
-        version: 1.12.0(react@19.2.0)
+        specifier: ^1.15.0
+        version: 1.15.0(react@19.2.0)
       '@radix-ui/react-popover':
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -1356,10 +1356,10 @@ packages:
   '@plasmohq/init@0.7.0':
     resolution: {integrity: sha512-P75g48dqOGneJ+n0AcqnLE/TYflcaPc3B7h6EopnCBBYUDnCNBMwYmKAkaf5pnhsEB0ybPS6TU1C2DTGfqaW7A==}
 
-  '@plasmohq/messaging@0.5.0':
-    resolution: {integrity: sha512-cYF750rguJDvnyJls2IHVAJTPVFtCEaMHMhnRsENfGaNqcRfXVfzwBGOABPg3k1iSBWBYLySh3Ht7QvFSnB3RQ==}
+  '@plasmohq/messaging@0.7.2':
+    resolution: {integrity: sha512-waIp827DRgy4KiF+eoWQBvlacltAGzD1LgeFdgMC0tF2eMSgSFmvIEZc/8irQUFTcG+nk/Z+ESTIS7MVX71iTQ==}
     peerDependencies:
-      react: ^16.8.6 || ^17 || ^18
+      react: ^16.8.6 || ^17 || ^18 || ^19.0.0
     peerDependenciesMeta:
       react:
         optional: true
@@ -1427,10 +1427,10 @@ packages:
     resolution: {integrity: sha512-/3oVbajt+DRqtbM0RkKFtfyZR8DVjcsYpj1jHqPParGVBiXwgP0D/8Bj5p5/5Iqihs08gzasTcjKcwQKKdj0og==}
     engines: {parcel: '>= 2.7.0'}
 
-  '@plasmohq/storage@1.12.0':
-    resolution: {integrity: sha512-LoCyO0PXl609ee8QKVEwVpkTyD/8WjYQhd0sxFomLxbdxsZC0LD4n8nv4nSegP5X8lYQBQnR/LMq4ZXoQh87wA==}
+  '@plasmohq/storage@1.15.0':
+    resolution: {integrity: sha512-zBZ2NyVyvZlql2XHsjkZDL0+bqF6lir9RygeTnkYGF253M8DZttuSvjpsmpK6OWYmRXjhEqJeubd3+Zq9kuZ0w==}
     peerDependencies:
-      react: ^16.8.6 || ^17 || ^18
+      react: ^16.8.6 || ^17 || ^18 || ^19.0.0
     peerDependenciesMeta:
       react:
         optional: true
@@ -3548,14 +3548,14 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.7:
-    resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@4.0.2:
-    resolution: {integrity: sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==}
-    engines: {node: ^14 || ^16 || >=18}
+  nanoid@5.1.5:
+    resolution: {integrity: sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==}
+    engines: {node: ^18 || >=20}
     hasBin: true
 
   needle@3.3.1:
@@ -5933,9 +5933,9 @@ snapshots:
 
   '@plasmohq/init@0.7.0': {}
 
-  '@plasmohq/messaging@0.5.0(react@19.2.0)':
+  '@plasmohq/messaging@0.7.2(react@19.2.0)':
     dependencies:
-      nanoid: 4.0.2
+      nanoid: 5.1.5
     optionalDependencies:
       react: 19.2.0
 
@@ -6234,7 +6234,7 @@ snapshots:
       - walrus
       - whiskers
 
-  '@plasmohq/storage@1.12.0(react@19.2.0)':
+  '@plasmohq/storage@1.15.0(react@19.2.0)':
     dependencies:
       pify: 6.1.0
     optionalDependencies:
@@ -8476,9 +8476,9 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.7: {}
+  nanoid@3.3.11: {}
 
-  nanoid@4.0.2: {}
+  nanoid@5.1.5: {}
 
   needle@3.3.1:
     dependencies:
@@ -8762,7 +8762,7 @@ snapshots:
 
   postcss@8.4.45:
     dependencies:
-      nanoid: 3.3.7
+      nanoid: 3.3.11
       picocolors: 1.1.0
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## Summary
Plasmo関連の依存パッケージを最新バージョンに更新しました。

- **@plasmohq/messaging**: 0.5.0 → 0.7.2
- **@plasmohq/storage**: 1.12.0 → 1.15.0

## 主な変更点
- React 19.0.0 のpeer dependencyサポートが追加されました
- nanoidの依存関係が最新版に更新されました（3.3.7 → 3.3.11, 4.0.2 → 5.1.5）

## Test plan
- [x] ビルドが正常に完了することを確認
- [x] リントが正常に完了することを確認
- [x] Plasmoのビルドシステムが正常に動作することを確認

すべての更新後に動作確認済みで、問題なく動作しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)