### PR TITLE
fix: 新しい PR 画面（/pull/N/changes）で Copy LGTM ボタンが表示されない問題を修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,8 @@ Copy LGTMは、Plasmoフレームワークで構築されたChrome拡張機能�
 
 **コンテンツスクリプト** (`src/contents/github-pr.tsx`):
 - `https://github.com/*`にマッチするGitHub PRページに注入される
-- `getInlineAnchor`を使用して`.pr-toolbar > .diffbar > .pr-review-tools`要素をターゲットにする
+- PRの差分ページ（旧UI: `/pull/N/files`、新UI: `/pull/N/changes`）でのみ動作する
+- `getInlineAnchorList`でボタンの挿入位置を決める。新UI: `button[class*="ReviewMenuButton"]`（ラベルは "Submit review" / "Submit comments"）の直後、旧UI: `.pr-toolbar > .diffbar > .pr-review-tools`の直後
 - 主な機能：ランダムなLGTM画像をPRレビューのテキストエリアにコピー
 - ユーザー設定に基づいて「Approve」ラジオボタンを自動選択（オプション）
 - 挿入前にテキストエリアに画像が既に存在するかチェック
@@ -100,8 +101,11 @@ TypeScriptのパスエイリアス`@/*`は`./src/*`にマップされます（ts
 4. ランダムに画像を選択
 5. テキストエリアに画像が既に存在するかチェック（`<img alt="LGTM"`を検索）
 6. HTMLを挿入：`<img alt="LGTM" src="${url}" width="600px" />`
-7. 自動選択が有効な場合、「Approve」ラジオボタンをチェック
+7. 自動選択が有効な場合、「Approve」ラジオボタンを`click()`で選択（Reactのcontrolled inputに反映させるため）
 
 ## GitHub連携
 
-拡張機能はGitHub PRのレビューツールセクションにUIを注入します。ID `pull_request_review_body`のテキストエリアと、ID `pull_request_review[event]_approve`のApproveラジオボタンをターゲットにします。
+拡張機能はGitHub PRのレビューツールセクションにUIを注入します。
+
+- 旧UI: ID `pull_request_review_body`のテキストエリアと、ID `pull_request_review[event]_approve`のApproveラジオボタン
+- 新UI（React製 Files changed）: `textarea[aria-label="Markdown value"]`と`input[type="radio"][name="reviewEvent"][value="approve"]`

--- a/src/contents/github-pr.tsx
+++ b/src/contents/github-pr.tsx
@@ -160,9 +160,16 @@ const findReviewChangesButton = (): HTMLButtonElement | null => {
       document.querySelectorAll<HTMLButtonElement>(
         'button[data-variant="primary"]',
       ),
-    ).find((btn) => btn.textContent?.includes("Submit review")) || null
+    ).find((btn) => isSubmitReviewButtonText(btn.textContent)) || null
   );
 };
+
+/**
+ * 新UIのレビューボタンのラベルかどうか
+ * ボタンのラベルはレビューの状態で "Submit review" / "Submit comments" と変わる
+ */
+const isSubmitReviewButtonText = (text: string | null | undefined): boolean =>
+  /Submit (review|comments)/.test(text ?? "");
 
 /**
  * レビューコメントのtextareaを取得（新旧UI両対応）
@@ -274,10 +281,11 @@ const findApproveRadioButton = (): HTMLInputElement | null => {
  * Approveラジオボタンを選択（React対応）
  */
 const selectApproveOption = (radioButton: HTMLInputElement) => {
-  radioButton.checked = true;
-  // Reactにイベントを通知
-  const changeEvent = new Event("change", { bubbles: true });
-  radioButton.dispatchEvent(changeEvent);
+  if (radioButton.checked || radioButton.disabled) {
+    return;
+  }
+  // click() ならネイティブの change イベントが発火し、React の controlled input でも状態が更新される
+  radioButton.click();
 };
 
 // ========================================
@@ -287,13 +295,17 @@ const selectApproveOption = (radioButton: HTMLInputElement) => {
 /**
  * Copy LGTMボタンを配置する位置を決定
  */
-export const getInlineAnchorList: PlasmoGetInlineAnchorList = async () => {
-  // PRのFilesページでのみ動作
-  const isPRFilesPage =
-    window.location.pathname.includes("/pull/") &&
-    window.location.pathname.includes("/files");
+/**
+ * PRの差分ページかどうか
+ * - 旧UI: /owner/repo/pull/123/files
+ * - 新UI: /owner/repo/pull/123/changes（/files はここへリダイレクトされる）
+ */
+const isPRFilesPage = (pathname: string): boolean =>
+  /\/pull\/\d+\/(files|changes)(\/|$)/.test(pathname);
 
-  if (!isPRFilesPage) {
+export const getInlineAnchorList: PlasmoGetInlineAnchorList = async () => {
+  // PRの差分ページでのみ動作
+  if (!isPRFilesPage(window.location.pathname)) {
     return [];
   }
 
@@ -312,7 +324,7 @@ export const getInlineAnchorList: PlasmoGetInlineAnchorList = async () => {
     ),
   );
   const submitReviewButton = primaryButtons.find((btn) =>
-    btn.textContent?.includes("Submit review"),
+    isSubmitReviewButtonText(btn.textContent),
   );
   if (submitReviewButton) {
     return [{ element: submitReviewButton, insertPosition: "afterend" }];


### PR DESCRIPTION
## 問題
新しい Files changed 画面（React 製）で Copy LGTM ボタンが表示されない。

## 原因
新 UI では `/pull/N/files` が **`/pull/N/changes` にリダイレクト**される。`getInlineAnchorList` 冒頭の `pathname.includes("/files")` が false になり、常に `[]` を返していた。

セレクタ自体（`button[class*="ReviewMenuButton"]`、`textarea[aria-label="Markdown value"]`、`input[name="reviewEvent"][value="approve"]`）はログイン済みの実ページで確認し、すべて現行 UI で有効。

## 変更
- パス判定を `/\/pull\/\d+\/(files|changes)(\/|$)/` に変更
- レビューボタンのラベルが状態で `Submit review` / `Submit comments` と変わるため、フォールバック検索を両方に対応
- Approve の自動選択を `checked = true` + `change` イベントから `click()` に変更（React の controlled input に確実に反映させるため）
- CLAUDE.md の該当箇所を更新

## 確認
- `refined-github/sandbox/pull/10/changes` で挿入ロジックを実行し、textarea に値を入れた後に Submit ボタンが有効化される（React に認識される）ことを確認
- Approve ラジオはその PR では disabled のため、`click()` の実動作は未確認（要: レビュー可能な PR での確認）
- `pnpm fix` / `tsc --noEmit` / `pnpm build` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
