### PR TITLE
docs: README の使い方を現在の挙動に合わせて更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src="./assets/icon.png" alt="Copy LGTM extension's icon" width="80px" />
   <h1 style="margin-top:12px;">Copy LGTM</h1>
-  <p>The easiest way to copy LGTM images on GitHub.</p>
+  <p>The easiest way to add LGTM images to your GitHub pull request reviews.</p>
   <video src="https://github.com/hayato-osh/copy-lgtm/assets/74091672/c1b068a1-0b4f-4723-8aaa-dae3fc8632a0">
     Demo
   </video>
@@ -10,10 +10,23 @@
 <h2>Usage</h2>
 <ol>
   <li>Install this extension in your browser.</li>
-  <li>Please review it in a pull request in any repository on GitHub.</li>
+  <li>Open the <b>Files changed</b> tab of any pull request on GitHub.</li>
   <li>
-    <p style="margin:0;">Click this button.</p>
+    <p style="margin:0;">Click the <b>Copy LGTM</b> button next to the review button.</p>
     <img src="./assets/github-lgtm.png" alt="GitHub Pull Request screen. The Copy LGTM button is located to the right of the Review Changes button and is highlighted with a red border." />
   </li>
-  <li>Now that the LGTM image has been copied on the clipboard, please Approve and paste the image.</li>
+  <li>The review dialog opens with a random LGTM image already inserted into the comment. Submit your review.</li>
 </ol>
+
+<h2>Options</h2>
+<p>Open the extension popup to configure:</p>
+<ul>
+  <li><b>Custom images</b>: register up to 8 of your own image URLs (<code>https://</code> only). When set, they are used instead of the built-in images.</li>
+  <li><b>Automatically select "Approve"</b>: check the "Approve" option in the review dialog when an LGTM image is inserted.</li>
+</ul>
+
+<h2>Supported pages</h2>
+<ul>
+  <li>The new "Files changed" experience (<code>/pull/N/changes</code>)</li>
+  <li>The legacy "Files changed" page (<code>/pull/N/files</code>)</li>
+</ul>


### PR DESCRIPTION
## 変更
README の Usage が「クリップボードにコピーされるので Approve して貼り付けて」という 2.x 時代の説明のままだったので、現在の挙動（Copy LGTM を押すとレビューダイアログが開き、画像が直接挿入される）に書き換えました。

- Usage を現在の挙動に更新
- Options（カスタム画像 URL 最大 8 件 / Approve 自動選択）を追記
- Supported pages（新 `/pull/N/changes` と旧 `/pull/N/files`）を追記

## 残課題
- `assets/github-lgtm.png` は旧 UI のスクリーンショットのまま。新 UI で撮り直したものに差し替えたい（拡張を読み込んだブラウザが必要なので未対応）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XacobABzGsnxANx76iuWkh
