### PR TITLE
chore: Renovate が pnpm-workspace.yaml の overrides を更新しないようにする

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,11 @@
   },
   "packageRules": [
     {
+      "description": "pnpm-workspace.yaml overrides are deliberate security floors with intentional ranges (e.g. svelte <5 keeps Plasmo's Parcel tree working); Renovate must not pin them or bump the ranges",
+      "matchDepTypes": ["pnpm-workspace.overrides"],
+      "enabled": false
+    },
+    {
       "description": "Plasmo and its runtime packages move together; bumping them separately risks a version mismatch at build time",
       "matchPackageNames": [
         "plasmo",


### PR DESCRIPTION
## 概要

#89 マージ後に `hayato-osh/renovate` で dry-run（[run 32853725723](https://github.com/hayato-osh/renovate/actions/runs/32853725723)）を回したところ、`copy-lgtm` は正しく検出されたものの、`pnpm-workspace.yaml` の `overrides` が更新対象として拾われていた（depType: `pnpm-workspace.overrides`）。

このままだと次の PR が作られる:

| ブランチ | 内容 |
| --- | --- |
| `renovate/pin-dependencies` | 全 overrides の範囲指定（`>=1.10.1` など）を exact にピン |
| `renovate/npm-svelte-4.2.19-vulnerability` | `svelte` を `>=4.2.19 <5` → `<6` に変更（Svelte 5 化。Plasmo の Parcel ツリーが壊れる） |
| `renovate/diff-=4.0.0-4.0.4-9.x` | `diff` を `>=4.0.4 <5` → `<10` に変更 |

overrides は脆弱性対策の下限を意図的に範囲で書いているものなので、Renovate には触らせない。

## 変更内容

`matchDepTypes: ["pnpm-workspace.overrides"]` に `enabled: false` の packageRule を追加（`renovate-config-validator` で検証済み）。

## dry-run で検出されたその他の更新（参考）

こちらは意図どおりで、マージ後の定期実行で PR が来る想定:

- GitHub Actions の major: `actions/checkout` v7, `actions/cache` v6, `actions/setup-node` v7, `pnpm/action-setup` v6
- toolchain: `node` 22.17.0 → 22.23.2（minor）/ 24.19.0（major）、`pnpm` 11.22.0 → 11.23.0
- `typescript` 6.0.3 → 7.0.2（major）
- `@biomejs/biome`, `@types/chrome`, `@types/node`, `@types/react-dom` の patch / minor
- lockFileMaintenance（月曜）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

