### PR TITLE
ci: バージョン更新から Chrome ウェブストア提出までを自動化

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,55 @@
+name: "Bump version"
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump type"
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - name: Use Node.js (.node-version)
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .node-version
+      - name: Bump package.json version
+        id: bump
+        env:
+          BUMP: ${{ inputs.bump }}
+        run: |
+          previous="$(node -p "require('./package.json').version")"
+          npm version "$BUMP" --no-git-tag-version
+          version="$(node -p "require('./package.json').version")"
+          echo "previous=$previous" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.bump.outputs.version }}
+          PREVIOUS: ${{ steps.bump.outputs.previous }}
+        run: |
+          branch="release/$VERSION"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add package.json
+          git commit -m "release: $VERSION"
+          git push origin "$branch"
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "release: $VERSION" \
+            --body "$(printf 'Bump version %s -> %s.\n\nマージすると `release.yml` が GitHub Release `%s` を作成し、Chrome ウェブストアへ提出します。' "$PREVIOUS" "$VERSION" "$VERSION")"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: "Release"
+on:
+  push:
+    branches: [main]
+    paths: [package.json]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+      created: ${{ steps.check.outputs.created }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - name: Create GitHub Release if the version is new
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          if git ls-remote --exit-code --tags origin "refs/tags/$version" >/dev/null; then
+            echo "Tag $version already exists; nothing to release."
+            echo "created=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          gh release create "$version" --target "$GITHUB_SHA" --title "$version" --generate-notes
+          echo "created=true" >> "$GITHUB_OUTPUT"
+
+  submit:
+    needs: tag
+    if: needs.tag.outputs.created == 'true'
+    uses: ./.github/workflows/submit.yml
+    with:
+      tag: ${{ needs.tag.outputs.version }}
+    secrets: inherit

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1,12 +1,40 @@
 name: "Submit to Web Store"
 on:
+  release:
+    types: [published]
+  workflow_call:
+    inputs:
+      tag:
+        description: "Release tag to attach the zip to"
+        required: true
+        type: string
+    secrets:
+      SUBMIT_KEYS:
+        required: true
   workflow_dispatch:
 
+permissions:
+  contents: write # Release に zip を添付するため
+
+env:
+  PLASMO_PUBLIC_IMAGES_JSON: https://raw.githubusercontent.com/hayato-osh/copy-lgtm/main/images
+  # release イベント / workflow_call のときだけ入る。workflow_dispatch では空
+  RELEASE_TAG: ${{ inputs.tag || github.event.release.tag_name }}
+
 jobs:
-  build:
+  submit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - name: Verify release tag matches package.json version
+        if: env.RELEASE_TAG != ''
+        run: |
+          pkg_version="$(node -p "require('./package.json').version")"
+          tag_version="${RELEASE_TAG#v}"
+          if [ "$pkg_version" != "$tag_version" ]; then
+            echo "::error::package.json version ($pkg_version) does not match release tag ($RELEASE_TAG)"
+            exit 1
+          fi
       - name: Cache pnpm modules
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
@@ -22,10 +50,17 @@ jobs:
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Lint
+        run: pnpm lint
       - name: Build the extension
         run: pnpm build
       - name: Package the extension into a zip artifact
         run: pnpm package
+      - name: Attach zip to the GitHub Release
+        if: env.RELEASE_TAG != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "$RELEASE_TAG" build/chrome-mv3-prod.zip --clobber
       - name: Browser Platform Publish
         uses: PlasmoHQ/bpp@c15984c0a74f452851c605cab46f34d9fd6cb158 # v3.8.0
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,3 +107,19 @@ TypeScriptのパスエイリアス`@/*`は`./src/*`にマップされます（ts
 
 - 旧UI: ID `pull_request_review_body`のテキストエリアと、ID `pull_request_review[event]_approve`のApproveラジオボタン
 - 新UI（React製 Files changed）: `textarea[aria-label="Markdown value"]`と`input[type="radio"][name="reviewEvent"][value="approve"]`
+
+## リリース（Chrome ウェブストアへの提出）
+
+3 つのワークフローで、バージョン更新から Chrome ウェブストアへの提出までを自動化している。
+
+1. **`bump-version.yml`**（手動実行）: `patch` / `minor` / `major` を選ぶと `package.json` の `version` を上げ、`release/x.y.z` ブランチから PR（`release: x.y.z`）を自動作成する
+2. **`release.yml`**（main への push で `package.json` が変わったとき）: そのバージョンのタグが無ければ GitHub Release（タグ名 = バージョン、`v` なし）を作成し、続けて `submit.yml` を `workflow_call` で呼ぶ。タグが既にあれば何もしない（Renovate 等の依存更新でも安全）
+3. **`submit.yml`**: lint → build → package → zip を Release に添付 → `PlasmoHQ/bpp` で Chrome ウェブストアへ提出。タグと `package.json` の version が一致しないと失敗する
+
+通常のリリース手順は「Actions → Bump version を実行 → できた PR をマージ」だけ。
+
+補足:
+- `GITHUB_TOKEN` で作成した Release は `release` イベントを発火しないため、`release.yml` から `submit.yml` を明示的に呼んでいる。手動で `gh release create` した場合は `release: published` トリガーで同じジョブが走る
+- `submit.yml` の手動実行（`workflow_dispatch`）は Release への添付をスキップして提出のみ行う。ストアは同一バージョンの再提出を拒否するので、認証確認用途
+- 必要なリポジトリシークレット: `SUBMIT_KEYS`（bpp 形式の JSON。`{"$chrome": {"clientId", "clientSecret", "refreshToken", "extId"}}`）
+- リポジトリ設定「Allow GitHub Actions to create and approve pull requests」が有効であること（`bump-version.yml` の PR 作成に必要）


### PR DESCRIPTION
## 概要

Chrome ウェブストアへの提出は `submit.yml` が手動実行専用のまま一度も動いていなかったので、バージョン更新から提出までを 3 つのワークフローで自動化する。

## 変更

- **`bump-version.yml`**（新規・手動実行）: `patch` / `minor` / `major` を選ぶと `package.json` を上げ、`release/x.y.z` ブランチから PR を自動作成
- **`release.yml`**（新規・main への push で `package.json` 変更時）: そのバージョンのタグが無ければ GitHub Release（タグ名 = バージョン、`v` なし）を作成し、`submit.yml` を `workflow_call` で呼ぶ。タグが既にあれば何もしない
- **`submit.yml`**（変更）: `workflow_call` 対応、タグと `package.json` の version 整合チェック、lint ステップ、zip を Release に添付、`PLASMO_PUBLIC_IMAGES_JSON` を設定
- `CLAUDE.md` にリリース手順を追記

`GITHUB_TOKEN` で作った Release は `release` イベントを発火しないため、`release.yml` から `submit.yml` を明示的に呼んでいる。

## リリース手順（マージ後）

1. Actions → Bump version → 種別を選んで Run
2. できた PR をマージ → Release 作成 → ビルド → zip 添付 → ストア提出まで自動

## 事前に必要なもの

- [ ] リポジトリシークレット `SUBMIT_KEYS`（`{"$chrome": {"clientId", "clientSecret", "refreshToken", "extId"}}`）
- [x] Settings → Actions → 「Allow GitHub Actions to create and approve pull requests」有効化済み

## 動作確認

- ローカルで `pnpm lint` / `pnpm build` / `pnpm package` が成功し `build/chrome-mv3-prod.zip` が生成されることを確認
- 3 ワークフローの YAML パースを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
