### PR TITLE
chore(renovate): group updates into patch/minor/major PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,9 @@
     "schedule": ["before 6am on monday"]
   },
   "vulnerabilityAlerts": {
-    "labels": ["security"]
+    "description": "脆弱性対応は patch/minor/major のまとめ PR に混ぜず、単独の security PR として先に出す",
+    "labels": ["security"],
+    "groupName": "security"
   },
   "packageRules": [
     {
@@ -20,19 +22,25 @@
       "enabled": false
     },
     {
-      "description": "Plasmo and its runtime packages move together; bumping them separately risks a version mismatch at build time",
-      "matchPackageNames": [
-        "plasmo",
-        "@plasmohq/messaging",
-        "@plasmohq/storage"
-      ],
-      "groupName": "plasmo"
-    },
-    {
       "description": "Treat Corepack-pinned pnpm and .node-version as toolchain chores",
       "matchDepNames": ["pnpm", "node"],
-      "semanticCommitType": "chore",
-      "groupName": "toolchain"
+      "semanticCommitType": "chore"
+    },
+    {
+      "description": "PR の数を抑えるため、更新の種類ごとに patch / minor / major の 3 本にまとめる（config:best-practices の monorepo グループより後に置いて上書きする）。digest / pinDigest（GitHub Actions の SHA 更新）は patch 扱い",
+      "matchUpdateTypes": ["patch", "digest", "pinDigest"],
+      "groupName": "patch dependencies",
+      "groupSlug": "patch"
+    },
+    {
+      "matchUpdateTypes": ["minor"],
+      "groupName": "minor dependencies",
+      "groupSlug": "minor"
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "groupName": "major dependencies",
+      "groupSlug": "major"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Renovate の PR が依存ごとに 1 本ずつ立っていたので、更新の種類ごとに **patch / minor / major の 3 本**にまとめる
- `patch` グループには `digest` / `pinDigest`（GitHub Actions の SHA 更新）も含める
- 脆弱性対応は `security` グループとして別出しし、まとめ PR に埋もれないようにする
- `plasmo` / `toolchain` グループは種類別グループに吸収されるため削除（`toolchain` の `semanticCommitType: chore` は維持）

## Notes
- `config:best-practices` の monorepo グループ（`react-monorepo` など）は末尾の packageRules で上書きされる
- マージ後、今開いている単発の Renovate PR（#96, #105, #107, #110）は次回実行時に自動クローズされ、まとめ PR に作り直される
- `plasmo` と `@plasmohq/*` の更新種類がズレた場合（片方だけ major など）だけ別 PR に分かれる

## Test plan
- [x] `npx renovate-config-validator renovate.json` → `Config validated successfully`
- [ ] マージ後の Renovate 実行で patch / minor / major のまとめ PR が立つことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkszZypAqNUzYaRZ3QooDs