### PR TITLE
chore(renovate): run on a weekly schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,8 @@
   "rangeStrategy": "pin",
   "description": "minimumReleaseAge は pnpm-workspace.yaml の minimumReleaseAge (4 days) より必ず長くする。逆転すると Renovate のロックファイル更新が pnpm に拒否され renovate/artifacts が落ちる",
   "minimumReleaseAge": "7 days",
+  "timezone": "Asia/Tokyo",
+  "schedule": ["before 6am on monday"],
   "prHourlyLimit": 5,
   "prConcurrentLimit": 10,
   "lockFileMaintenance": {


### PR DESCRIPTION
## Summary
- Renovate が毎日 PR を作成・更新していたので、実行を **毎週月曜 6 時（JST）まで** に制限する
- `timezone: Asia/Tokyo` を追加（スケジュールを JST で解釈させるため）
- `lockFileMaintenance` の既存スケジュール（monday before 6am）と同じ窓に揃えた

## Notes
- 脆弱性対応（vulnerabilityAlerts）は Renovate のデフォルトでスケジュールを無視するため、これまで通り即時に PR が立つ
- 既存の open PR（#113, #114）へのリベース・更新も月曜の窓でのみ行われるようになる

## Test plan
- [x] `npx renovate-config-validator renovate.json` → `Config validated successfully`
- [ ] 平日に Renovate の新規 PR / リベースが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkszZypAqNUzYaRZ3QooDs